### PR TITLE
Fix wrong value argument passed to tabPanel() by miniTabPanel()

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -90,7 +90,7 @@ miniTabstripPanel <- function(..., id = NULL, selected = NULL, between = NULL) {
 #' @rdname miniTabstripPanel
 #' @export
 miniTabPanel <- function(title, ..., value = title, icon = NULL) {
-  tabPanel(title, value = title, icon = icon,
+  tabPanel(title, value = value, icon = icon,
     tags$div(class = "gadget-tabs-content-inner", ...)
   )
 }


### PR DESCRIPTION
`miniTabPanel()` systematically pass the `title` argument to `tabPanel()`'s `value`, whereas it should pass its own `value` argument instead.
